### PR TITLE
terraform: fix makefile syntax issue

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -49,10 +49,10 @@ clean: init
 	@rm -f .deploy.$(ENVIRONMENT) .MGMT_ADDRESS.$(ENVIRONMENT)
 	@rm -f .id_rsa.$(ENVIRONMENT)
 
-        if [[ ! $$ENVIRONMENT != default ]]; \
+	if [[ ! $$ENVIRONMENT != default ]]; \
 	  @terraform workspace select default; \
 	  @terraform workspace delete $(ENVIRONMENT); \
-        fi
+	fi
 
 purge:
 	@echo "Warning, going to delete ALL resources in $(ENVIRONMENT), even those that have not been created by the testbed."
@@ -67,10 +67,10 @@ purge:
 	@openstack keypair delete garden-cluster-$(ENVIRONMENT)
 	@ospurge --purge-own-project --os-cloud $(ENVIRONMENT) --verbose
 
-        if [[ ! $$ENVIRONMENT != default ]]; \
+	if [[ ! $$ENVIRONMENT != default ]]; \
 	  @terraform workspace select default; \
 	  @terraform workspace delete force $(ENVIRONMENT); \
-        fi
+	fi
 
 purge-ssh-keys:
 	for i in `openstack --os-cloud $(ENVIROMENT) keypair list -c Name -f value`; do openstack keypair delete $$i; done


### PR DESCRIPTION
Makefile:52: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.

Signed-off-by: Christian Berendt <berendt@23technologies.cloud>