### PR TITLE
github: use terragrunt

### DIFF
--- a/.github/workflows/daily-betacloud.yml
+++ b/.github/workflows/daily-betacloud.yml
@@ -71,6 +71,10 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.14.2
+      - name: Setup Terragrunt
+        uses: autero1/action-terragrunt@v1.0.0
+        with:
+          terragrunt_version: 0.27.3
       - name: Display IP
         shell: bash
         working-directory: ./terraform
@@ -98,8 +102,8 @@ jobs:
         run: |
           echo "$MINIO" > minio.env
       - name: Initialization
-        run: make ENVIRONMENT=standard init
+        run: make ENVIRONMENT=standard TERRAFORM=terragrunt init
         working-directory: ./terraform
       - name: Deploy environment
-        run: make ENVIRONMENT=standard create
+        run: make ENVIRONMENT=standard TERRAFORM=terragrunt create
         working-directory: ./terraform

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,0 +1,3 @@
+retryable_errors = [
+  "(?s).*Error creating.*rule: Internal Server Error.*"
+]


### PR DESCRIPTION
With terragrunt it is possible to auto retry. This will solve the
following issue:

Error: Error creating openstack_compute_secgroup_v2 garden-cluster-mgmt
rule: Internal Server Error

Signed-off-by: Christian Berendt <berendt@23technologies.cloud>